### PR TITLE
H Tag 내용에 부등호 괄호가 포함되어 있을 때 화면에서 보이지 않는 현상 수정

### DIFF
--- a/dev/dev-toc.js
+++ b/dev/dev-toc.js
@@ -157,6 +157,7 @@ const TOC_CARD = (function () {
 
     const createTagItemByLevel = function (level = CONSTANTS.NUM_OF_H1, hTag, indexOfHTag) {
       const basicItem = createBasicItemBy(hTag, indexOfHTag);
+      
       appendScrollEventsOn(basicItem, indexOfHTag);
 
       basicItem.classList.add(`toc-level-${level}`);
@@ -166,19 +167,20 @@ const TOC_CARD = (function () {
 
     const createBasicItemBy = function (hTag, indexOfHTag) {
       const basicItem = document.createElement('a');
-      
-      /* hTag 내용에 부등호 괄호가 포함되어 있을 때, 이를 html 특수문자 코드로 변경 */
+      let hTagInnerText = hTag.innerText;
+
+      /* H tag 내용에 부등호 괄호가 포함되어 있을 때, 이를 html 특수문자 코드로 변경 */
       if (hTag.innerText.includes('<')) {
-        hTag.innerText = hTag.innerText.replace(/&lt;/g, '&amp;lt;');
-        hTag.innerText = hTag.innerText.replace(/</g, '&lt;');
-      }
-      
-      if (hTag.innerText.includes('>')) {
-        hTag.innerText = hTag.innerText.replace(/&gt;/g, '&amp;gt;');
-        hTag.innerText = hTag.innerText.replace(/>/g, '&gt;');
+        hTagInnerText = hTagInnerText.replace(/&lt;/g, '&amp;lt;');
+        hTagInnerText = hTagInnerText.replace(/</g, '&lt;');
       }
 
-      basicItem.innerHTML += hTag.innerText;
+      if (hTag.innerText.includes('>')) {
+        hTagInnerText = hTagInnerText.replace(/&gt;/g, '&amp;gt;');
+        hTagInnerText = hTagInnerText.replace(/>/g, '&gt;');
+      }
+
+      basicItem.innerHTML += hTagInnerText;
       basicItem.id = `toc-${indexOfHTag}`;
       basicItem.classList = 'toc-common';
 

--- a/dev/dev-toc.js
+++ b/dev/dev-toc.js
@@ -166,6 +166,17 @@ const TOC_CARD = (function () {
 
     const createBasicItemBy = function (hTag, indexOfHTag) {
       const basicItem = document.createElement('a');
+      
+      /* hTag 내용에 부등호 괄호가 포함되어 있을 때, 이를 html 특수문자 코드로 변경 */
+      if (hTag.innerText.includes('<')) {
+        hTag.innerText = hTag.innerText.replace(/&lt;/g, '&amp;lt;');
+        hTag.innerText = hTag.innerText.replace(/</g, '&lt;');
+      }
+      
+      if (hTag.innerText.includes('>')) {
+        hTag.innerText = hTag.innerText.replace(/&gt;/g, '&amp;gt;');
+        hTag.innerText = hTag.innerText.replace(/>/g, '&gt;');
+      }
 
       basicItem.innerHTML += hTag.innerText;
       basicItem.id = `toc-${indexOfHTag}`;

--- a/toc.js
+++ b/toc.js
@@ -157,6 +157,7 @@ const TOC_CARD = (function () {
 
     const createTagItemByLevel = function (level = CONSTANTS.NUM_OF_H1, hTag, indexOfHTag) {
       const basicItem = createBasicItemBy(hTag, indexOfHTag);
+
       appendScrollEventsOn(basicItem, indexOfHTag);
 
       basicItem.classList.add(`toc-level-${level}`);
@@ -166,19 +167,20 @@ const TOC_CARD = (function () {
 
     const createBasicItemBy = function (hTag, indexOfHTag) {
       const basicItem = document.createElement('a');
+      let hTagInnerText = hTag.innerText;
 
-      /* hTag 내용에 부등호 괄호가 포함되어 있을 때, 이를 html 특수문자 코드로 변경 */
+      /* H tag 내용에 부등호 괄호가 포함되어 있을 때, 이를 html 특수문자 코드로 변경 */
       if (hTag.innerText.includes('<')) {
-        hTag.innerText = hTag.innerText.replace(/&lt;/g, '&amp;lt;');
-        hTag.innerText = hTag.innerText.replace(/</g, '&lt;');
-      }
-      
-      if (hTag.innerText.includes('>')) {
-        hTag.innerText = hTag.innerText.replace(/&gt;/g, '&amp;gt;');
-        hTag.innerText = hTag.innerText.replace(/>/g, '&gt;');
+        hTagInnerText = hTagInnerText.replace(/&lt;/g, '&amp;lt;');
+        hTagInnerText = hTagInnerText.replace(/</g, '&lt;');
       }
 
-      basicItem.innerHTML += hTag.innerText;
+      if (hTag.innerText.includes('>')) {
+        hTagInnerText = hTagInnerText.replace(/&gt;/g, '&amp;gt;');
+        hTagInnerText = hTagInnerText.replace(/>/g, '&gt;');
+      }
+
+      basicItem.innerHTML += hTagInnerText;
       basicItem.id = `toc-${indexOfHTag}`;
       basicItem.classList = 'toc-common';
 

--- a/toc.js
+++ b/toc.js
@@ -167,6 +167,17 @@ const TOC_CARD = (function () {
     const createBasicItemBy = function (hTag, indexOfHTag) {
       const basicItem = document.createElement('a');
 
+      /* hTag 내용에 부등호 괄호가 포함되어 있을 때, 이를 html 특수문자 코드로 변경 */
+      if (hTag.innerText.includes('<')) {
+        hTag.innerText = hTag.innerText.replace(/&lt;/g, '&amp;lt;');
+        hTag.innerText = hTag.innerText.replace(/</g, '&lt;');
+      }
+      
+      if (hTag.innerText.includes('>')) {
+        hTag.innerText = hTag.innerText.replace(/&gt;/g, '&amp;gt;');
+        hTag.innerText = hTag.innerText.replace(/>/g, '&gt;');
+      }
+
       basicItem.innerHTML += hTag.innerText;
       basicItem.id = `toc-${indexOfHTag}`;
       basicItem.classList = 'toc-common';


### PR DESCRIPTION
안녕하세요, @wbluke 님.
`dev-toc.js` 와 `toc.js` 파일의 `createBasicItemBy` 함수에서 **H Tag 내용에 부등호 괄호가 포함되어 있을 때, 이를 HTML 특수문자 코드로 변경하는 코드**를 추가하였습니다.
테스트 완료하였고, 위 수정사항이 적용된 [티스토리 블로그 글](https://qqyukim.tistory.com/48)의 TOC 화면 이미지를 아래에 첨부하오니 확인 부탁드립니다.
감사합니다!

![image](https://user-images.githubusercontent.com/54669221/101155202-20d20480-366a-11eb-9dd8-56d315eab983.png)

