### PR TITLE
H Tag 내용에 부등호 괄호가 포함되어 있을 때, 포스트 내용은 그대로 두고 TOC의 부등호가 HTML 코드로 변환

### DIFF
--- a/dev/dev-toc.js
+++ b/dev/dev-toc.js
@@ -157,6 +157,7 @@ const TOC_CARD = (function () {
 
     const createTagItemByLevel = function (level = CONSTANTS.NUM_OF_H1, hTag, indexOfHTag) {
       const basicItem = createBasicItemBy(hTag, indexOfHTag);
+      
       appendScrollEventsOn(basicItem, indexOfHTag);
 
       basicItem.classList.add(`toc-level-${level}`);
@@ -166,19 +167,20 @@ const TOC_CARD = (function () {
 
     const createBasicItemBy = function (hTag, indexOfHTag) {
       const basicItem = document.createElement('a');
-      
-      /* hTag 내용에 부등호 괄호가 포함되어 있을 때, 이를 html 특수문자 코드로 변경 */
+      let hTagInnerText = hTag.innerText;
+
+      /* H tag 내용에 부등호 괄호가 포함되어 있을 때, 이를 html 특수문자 코드로 변경 */
       if (hTag.innerText.includes('<')) {
-        hTag.innerText = hTag.innerText.replace(/&lt;/g, '&amp;lt;');
-        hTag.innerText = hTag.innerText.replace(/</g, '&lt;');
-      }
-      
-      if (hTag.innerText.includes('>')) {
-        hTag.innerText = hTag.innerText.replace(/&gt;/g, '&amp;gt;');
-        hTag.innerText = hTag.innerText.replace(/>/g, '&gt;');
+        hTagInnerText = hTagInnerText.replace(/&lt;/g, '&amp;lt;');
+        hTagInnerText = hTagInnerText.replace(/</g, '&lt;');
       }
 
-      basicItem.innerHTML += hTag.innerText;
+      if (hTag.innerText.includes('>')) {
+        hTagInnerText = hTagInnerText.replace(/&gt;/g, '&amp;gt;');
+        hTagInnerText = hTagInnerText.replace(/>/g, '&gt;');
+      }
+
+      basicItem.innerHTML += hTagInnerText;
       basicItem.id = `toc-${indexOfHTag}`;
       basicItem.classList = 'toc-common';
 

--- a/dev/dev-toc.js
+++ b/dev/dev-toc.js
@@ -166,6 +166,17 @@ const TOC_CARD = (function () {
 
     const createBasicItemBy = function (hTag, indexOfHTag) {
       const basicItem = document.createElement('a');
+      
+      /* hTag 내용에 부등호 괄호가 포함되어 있을 때, 이를 html 특수문자 코드로 변경 */
+      if (hTag.innerText.includes('<')) {
+        hTag.innerText = hTag.innerText.replace(/&lt;/g, '&amp;lt;');
+        hTag.innerText = hTag.innerText.replace(/</g, '&lt;');
+      }
+      
+      if (hTag.innerText.includes('>')) {
+        hTag.innerText = hTag.innerText.replace(/&gt;/g, '&amp;gt;');
+        hTag.innerText = hTag.innerText.replace(/>/g, '&gt;');
+      }
 
       basicItem.innerHTML += hTag.innerText;
       basicItem.id = `toc-${indexOfHTag}`;

--- a/toc.js
+++ b/toc.js
@@ -157,6 +157,7 @@ const TOC_CARD = (function () {
 
     const createTagItemByLevel = function (level = CONSTANTS.NUM_OF_H1, hTag, indexOfHTag) {
       const basicItem = createBasicItemBy(hTag, indexOfHTag);
+
       appendScrollEventsOn(basicItem, indexOfHTag);
 
       basicItem.classList.add(`toc-level-${level}`);
@@ -166,19 +167,20 @@ const TOC_CARD = (function () {
 
     const createBasicItemBy = function (hTag, indexOfHTag) {
       const basicItem = document.createElement('a');
+      let hTagInnerText = hTag.innerText;
 
-      /* hTag 내용에 부등호 괄호가 포함되어 있을 때, 이를 html 특수문자 코드로 변경 */
+      /* H tag 내용에 부등호 괄호가 포함되어 있을 때, 이를 html 특수문자 코드로 변경 */
       if (hTag.innerText.includes('<')) {
-        hTag.innerText = hTag.innerText.replace(/&lt;/g, '&amp;lt;');
-        hTag.innerText = hTag.innerText.replace(/</g, '&lt;');
-      }
-      
-      if (hTag.innerText.includes('>')) {
-        hTag.innerText = hTag.innerText.replace(/&gt;/g, '&amp;gt;');
-        hTag.innerText = hTag.innerText.replace(/>/g, '&gt;');
+        hTagInnerText = hTagInnerText.replace(/&lt;/g, '&amp;lt;');
+        hTagInnerText = hTagInnerText.replace(/</g, '&lt;');
       }
 
-      basicItem.innerHTML += hTag.innerText;
+      if (hTag.innerText.includes('>')) {
+        hTagInnerText = hTagInnerText.replace(/&gt;/g, '&amp;gt;');
+        hTagInnerText = hTagInnerText.replace(/>/g, '&gt;');
+      }
+
+      basicItem.innerHTML += hTagInnerText;
       basicItem.id = `toc-${indexOfHTag}`;
       basicItem.classList = 'toc-common';
 

--- a/toc.js
+++ b/toc.js
@@ -167,6 +167,17 @@ const TOC_CARD = (function () {
     const createBasicItemBy = function (hTag, indexOfHTag) {
       const basicItem = document.createElement('a');
 
+      /* hTag 내용에 부등호 괄호가 포함되어 있을 때, 이를 html 특수문자 코드로 변경 */
+      if (hTag.innerText.includes('<')) {
+        hTag.innerText = hTag.innerText.replace(/&lt;/g, '&amp;lt;');
+        hTag.innerText = hTag.innerText.replace(/</g, '&lt;');
+      }
+      
+      if (hTag.innerText.includes('>')) {
+        hTag.innerText = hTag.innerText.replace(/&gt;/g, '&amp;gt;');
+        hTag.innerText = hTag.innerText.replace(/>/g, '&gt;');
+      }
+
       basicItem.innerHTML += hTag.innerText;
       basicItem.id = `toc-${indexOfHTag}`;
       basicItem.classList = 'toc-common';


### PR DESCRIPTION
안녕하세요, @wbluke 님.
블로그 글을 꼼꼼하게 살펴주셔서 감사합니다.
포스트 내용의 부등호까지 HTML 특수문자 기호로 바뀌는 것을 간과하였습니다. 😂

코드를 수정하여 [버그가 있던 곳](https://qqyukim.tistory.com/48)이 제대로 나오는지 확인한 뒤, 요청하신대로 develop 브랜치로 PR을 드립니다.